### PR TITLE
LIBSEARCH-4 Added Rubocop and got basic testing working

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,63 @@
+# Enables Rails cops
+Rails:
+  Enabled: true
+
+# Don't require gems in Gemfile to be in alphabetical order.
+Bundler/OrderedGems:
+  Enabled: false
+
+# Exclude auto-generated files
+AllCops:
+  Include:
+    - '**/Gemfile'
+    - '**/Rakefile'
+  Exclude:
+    - 'bin/*'
+    - 'config/initializers/*'
+    - 'config/application.rb'
+    - 'db/schema.rb'
+    - 'db/migrate/*'
+    - 'lib/**/*'
+    - 'db/seeds.rb'
+    - 'test/dummy/**/*'
+
+  TargetRubyVersion: 2.2
+  TargetRailsVersion: 5.0
+
+# Increase max allowed line length
+Metrics/LineLength:
+  Max: 120
+
+Metrics/ClassLength:
+  Exclude:
+    - 'test/**/*'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'test/**/*'
+
+Metrics/ModuleLength:
+  Exclude:
+    - 'test/**/*'
+
+# The following configuration exclude checks that seem
+# silly, or conflict with the way Rails naturally does
+# things.
+Style/Documentation:
+  Exclude:
+    - 'app/controllers/*_controller.rb'
+    - 'app/helpers/*_helper.rb'
+    - 'test/test_helper.rb'
+    - 'test/controllers/*_controller_test.rb'
+    - 'test/helpers/*_helper_test.rb'
+
+Style/ClassAndModuleChildren:
+  Exclude:
+    - 'test/test_helper.rb'
+
+Layout/IndentationConsistency:
+  EnforcedStyle: rails
+
+Naming/FileName:
+  Exclude:
+    - quick_search-lib_guides_searcher.gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (8.0.0)
+    ast (2.4.0)
     builder (3.2.3)
     concurrent-ruby (1.0.5)
     crass (1.0.3)
@@ -82,6 +83,10 @@ GEM
     nio4r (2.2.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
+    parallel (1.12.1)
+    parser (2.5.0.2)
+      ast (~> 2.4.0)
+    powerpack (0.1.1)
     quick_search-core (0.1.1)
       fastimage
       httpclient
@@ -117,8 +122,17 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (3.0.0)
     rake (12.3.0)
     ref (2.0.0)
+    rubocop (0.52.1)
+      parallel (~> 1.10)
+      parser (>= 2.4.0.2, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.9.0)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -133,6 +147,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    unicode-display_width (1.3.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -142,6 +157,7 @@ PLATFORMS
 
 DEPENDENCIES
   quick_search-lib_guides_searcher!
+  rubocop (= 0.52.1)
 
 BUNDLED WITH
    1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sqlite3 (1.3.13)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
       ref
@@ -158,6 +159,7 @@ PLATFORMS
 DEPENDENCIES
   quick_search-lib_guides_searcher!
   rubocop (= 0.52.1)
+  sqlite3
 
 BUNDLED WITH
    1.16.1

--- a/Rakefile
+++ b/Rakefile
@@ -14,13 +14,10 @@ RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_files.include('lib/**/*.rb')
 end
 
-APP_RAKEFILE = File.expand_path("../test/dummy/Rakefile", __FILE__)
+APP_RAKEFILE = File.expand_path('../test/dummy/Rakefile', __FILE__)
 load 'rails/tasks/engine.rake'
 
-
 load 'rails/tasks/statistics.rake'
-
-
 
 require 'bundler/gem_tasks'
 
@@ -32,6 +29,5 @@ Rake::TestTask.new(:test) do |t|
   t.pattern = 'test/**/*_test.rb'
   t.verbose = false
 end
-
 
 task default: :test

--- a/app/searchers/quick_search/lib_guides_searcher.rb
+++ b/app/searchers/quick_search/lib_guides_searcher.rb
@@ -1,15 +1,14 @@
 module QuickSearch
+  # QuickSearch seacher for LibGuides
   class LibGuidesSearcher < QuickSearch::Searcher
-
     def search
       resp = @http.get(base_url)
       @response = JSON.parse(resp.body)
     end
 
-    def results
+    def results # rubocop:disable Metrics/MethodLength
       if results_list
         results_list
-
       else
         @results_list = []
 
@@ -23,11 +22,13 @@ module QuickSearch
 
         @results_list
       end
-
     end
 
     def base_url
-      QuickSearch::Engine::LIB_GUIDES_CONFIG['base_url'] + QuickSearch::Engine::LIB_GUIDES_CONFIG['key'] + QuickSearch::Engine::LIB_GUIDES_CONFIG['query_params'] + http_request_queries['not_escaped']
+      QuickSearch::Engine::LIB_GUIDES_CONFIG['base_url'] +
+        QuickSearch::Engine::LIB_GUIDES_CONFIG['key'] +
+        QuickSearch::Engine::LIB_GUIDES_CONFIG['query_params'] +
+        http_request_queries['not_escaped']
     end
 
     def total
@@ -37,7 +38,5 @@ module QuickSearch
     def loaded_link
       QuickSearch::Engine::LIB_GUIDES_CONFIG['loaded_link'] + http_request_queries['uri_escaped']
     end
-
-
   end
 end

--- a/quick_search-lib_guides_searcher.gemspec
+++ b/quick_search-lib_guides_searcher.gemspec
@@ -1,20 +1,21 @@
-$:.push File.expand_path("../lib", __FILE__)
+$LOAD_PATH.push File.expand_path('../lib', __FILE__)
 
 # Maintain your gem's version:
-require "quick_search/lib_guides_searcher/version"
+require 'quick_search/lib_guides_searcher/version'
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
-  s.name        = "quick_search-lib_guides_searcher"
+  s.name        = 'quick_search-lib_guides_searcher'
   s.version     = QuickSearchLibGuidesSearcher::VERSION
-  s.authors     = ["UMD Libraries"]
-  s.email       = ["lib-ssdr@umd.edu"]
-  s.homepage    = "https://www.lib.umd.edu/"
-  s.summary     = "LibGuides searcher for NCSU Quick Search"
-  s.description = "LibGuides searcher for NCSU Quick Search."
-  s.license     = "Apache 2.0"
+  s.authors     = ['UMD Libraries']
+  s.email       = ['lib-ssdr@umd.edu']
+  s.homepage    = 'https://www.lib.umd.edu/'
+  s.summary     = 'LibGuides searcher for NCSU Quick Search'
+  s.description = 'LibGuides searcher for NCSU Quick Search.'
+  s.license     = 'Apache 2.0'
 
-  s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
+  s.files = Dir['{app,config,db,lib}/**/*', 'LICENSE', 'Rakefile', 'README.md']
 
-  s.add_dependency "quick_search-core", '~> 0'
+  s.add_dependency 'quick_search-core', '~> 0'
+  s.add_development_dependency 'rubocop', '= 0.52.1'
 end

--- a/quick_search-lib_guides_searcher.gemspec
+++ b/quick_search-lib_guides_searcher.gemspec
@@ -18,4 +18,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'quick_search-core', '~> 0'
   s.add_development_dependency 'rubocop', '= 0.52.1'
+  # sqlite3 loaded for testing with the "dummy" application
+  s.add_development_dependency 'sqlite3'
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -3,7 +3,8 @@ require_relative 'boot'
 require 'rails/all'
 
 Bundler.require(*Rails.groups)
-require "quick_search/lib_guides_searcher"
+require 'quick_search'
+require 'quick_search/lib_guides_searcher'
 
 module Dummy
   class Application < Rails::Application
@@ -12,4 +13,3 @@ module Dummy
     # -- all .rb files in that directory are automatically loaded.
   end
 end
-

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  mount QuickSearch::LibGuidesSearcher::Engine => "/quick_search-lib_guides_searcher"
+  mount QuickSearchLibGuidesSearcher::Engine => "/quick_search-lib_guides_searcher"
 end

--- a/test/integration/navigation_test.rb
+++ b/test/integration/navigation_test.rb
@@ -5,4 +5,3 @@ class NavigationTest < ActionDispatch::IntegrationTest
   #   assert true
   # end
 end
-

--- a/test/quick_search/lib_guides_searcher_test.rb
+++ b/test/quick_search/lib_guides_searcher_test.rb
@@ -1,7 +1,12 @@
 require 'test_helper'
 
-class QuickSearch::LibGuidesSearcher::Test < ActiveSupport::TestCase
-  test "truth" do
-    assert_kind_of Module, QuickSearch::LibGuidesSearcher
+module QuickSearch
+  class LibGuidesSearcher
+    # LibGuidesSearch tests
+    class Test < ActiveSupport::TestCase
+      test 'truth' do
+        assert_kind_of Module, QuickSearch::LibGuidesSearcher
+      end
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,20 +1,19 @@
 # Configure Rails Environment
-ENV["RAILS_ENV"] = "test"
+ENV['RAILS_ENV'] = 'test'
 
-require File.expand_path("../../test/dummy/config/environment.rb", __FILE__)
-ActiveRecord::Migrator.migrations_paths = [File.expand_path("../../test/dummy/db/migrate", __FILE__)]
+require File.expand_path('../../test/dummy/config/environment.rb', __FILE__)
+ActiveRecord::Migrator.migrations_paths = [File.expand_path('../../test/dummy/db/migrate', __FILE__)]
 ActiveRecord::Migrator.migrations_paths << File.expand_path('../../db/migrate', __FILE__)
-require "rails/test_help"
+require 'rails/test_help'
 
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new
 
-
 # Load fixtures from the engine
 if ActiveSupport::TestCase.respond_to?(:fixture_path=)
-  ActiveSupport::TestCase.fixture_path = File.expand_path("../fixtures", __FILE__)
+  ActiveSupport::TestCase.fixture_path = File.expand_path('../fixtures', __FILE__)
   ActionDispatch::IntegrationTest.fixture_path = ActiveSupport::TestCase.fixture_path
-  ActiveSupport::TestCase.file_fixture_path = ActiveSupport::TestCase.fixture_path + "/files"
+  ActiveSupport::TestCase.file_fixture_path = ActiveSupport::TestCase.fixture_path + '/files'
   ActiveSupport::TestCase.fixtures :all
 end


### PR DESCRIPTION
Added Rubocop and fixed warnings

Got testing working, albeit with some deprecation
warnings, i.e.,

```
DEPRECATION WARNING: ActiveSupport.halt_callback_chains_on_return_false= is deprecated and will be removed in Rails 5.2. (called from <top (required)> at /Users/dsteelma/work/github/quick_search-lib_guides_searcher/test/dummy/config/initializers/new_framework_defaults.rb:21)
DEPRECATION WARNING: ActiveSupport.halt_callback_chains_on_return_false= is deprecated and will be removed in Rails 5.2. (called from <top (required)> at /Users/dsteelma/work/github/quick_search-lib_guides_searcher/test/dummy/config/initializers/new_framework_defaults.rb:21)
/Users/dsteelma/work/github/quick_search-lib_guides_searcher/test/dummy/db/schema.rb doesn't exist yet. Run `rails db:migrate` to create it, then try again. If you do not intend to use a database, you should instead alter /Users/dsteelma/work/github/quick_search-lib_guides_searcher/test/dummy/config/application.rb to limit the frameworks that will be loaded.
```

https://issues.umd.edu/browse/LIBSEARCH-4