### PR TITLE
LIBSEARCH-18. Fixed misspelling of "error_service_message" property

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,6 @@ en:
     short_display_name: "LibGuides"
     search_form_placeholder: "Search LibGuides"
     module_callout: "Search LibGuides"
-    error_service_mesasge: "searching LibGuides"
+    error_service_message: "searching LibGuides"
     no_results_service_message: "a different search from LibGuides"
     no_results_link: "<NO_RESULTS_LINK>"


### PR DESCRIPTION
https://issues.umd.edu/browse/LIBSEARCH-18